### PR TITLE
Update dg_paths.php

### DIFF
--- a/dg_paths.php
+++ b/dg_paths.php
@@ -3,9 +3,9 @@
 // Use absolute paths for client-side files (CSS and JS) to enable grids at different levels of client side depth
 
 $this->paths = array(
-   css_path => '/common/libraries/datagrid/css/',
-   js_path => '/common/libraries/datagrid/js/',
-   tiny_mce_path => '/common/libraries/datagrid/js/tiny_mce/',
+   css_path => '/common/libraries/Datagridle/css/',
+   js_path => '/common/libraries/Datagridle/js/',
+   tiny_mce_path => '/common/libraries/Datagridle/js/tiny_mce/',
    classes_path => '../../../'
 );
 


### PR DESCRIPTION
You have the default path using the old name, 'datagrid', instead of what folks get when they download it now — 'Datagridle'. This fixes it.
