### PR TITLE
Update datagrid.css

### DIFF
--- a/css/datagrid.css
+++ b/css/datagrid.css
@@ -2,7 +2,6 @@
 
 body{
   font-family: arial;
-  color:color: #449977;
 }
 
 


### PR DESCRIPTION
You were setting the `body` text to `color:color: #449977;` which was broken, and when it works it sets it to an ugly green. Looked like a mistake.
