### PR TITLE
fix field size change on ajax edit.

### DIFF
--- a/css/datagrid.css
+++ b/css/datagrid.css
@@ -497,6 +497,7 @@ color:#ffffff;
   margin: 0;
   font-family: inherit;
   font-size: inherit;
+  width: 100%;
 }
 
 .ajax-edit select option, .ajax-edit select{


### PR DESCRIPTION
adding `width: 100%`; to `ajax-edit textarea` prevents it from bopping around when ajax edit is activated